### PR TITLE
removed dublicate + from packet

### DIFF
--- a/minigdbstub.h
+++ b/minigdbstub.h
@@ -363,7 +363,7 @@ static void minigdbstubSendSignal(mgdbProcObj *mgdbObj) {
 
     // Add the two checksum hex chars
     char checksumHex[8] = {0,0,0,0,0,0,0,0};
-    minigdbstubComputeChecksum(&sendPkt.buffer[2], bufferPtr+1, checksumHex);
+    minigdbstubComputeChecksum(&sendPkt.buffer[1], bufferPtr+1, checksumHex);
     insertDynCharBuffer(&sendPkt, checksumHex[0]);
     insertDynCharBuffer(&sendPkt, checksumHex[1]);
     insertDynCharBuffer(&sendPkt, 0);

--- a/minigdbstub.h
+++ b/minigdbstub.h
@@ -341,7 +341,6 @@ static void minigdbstubReadMem(mgdbProcObj *mgdbObj, gdbPacket *recvPkt) {
 static void minigdbstubSendSignal(mgdbProcObj *mgdbObj) {
     DynCharBuffer sendPkt;
     initDynCharBuffer(&sendPkt, 32);
-    insertDynCharBuffer(&sendPkt, '+');
     insertDynCharBuffer(&sendPkt, '$');
     insertDynCharBuffer(&sendPkt, 'S');
 

--- a/tests/test_send.cpp
+++ b/tests/test_send.cpp
@@ -17,8 +17,8 @@ static void cmpCharArrays(char *arr1, char *arr2, size_t size) {
 
 static void buildSignalPkt(std::stringstream *s, int signal) {
     char checksum[8];
-    *(s) << "+$S" << std::setw(2) << std::setfill('0') << signal;
-    minigdbstubComputeChecksum(const_cast<char*>(s->str().c_str()+2), 3, checksum);
+    *(s) << "$S" << std::setw(2) << std::setfill('0') << signal;
+    minigdbstubComputeChecksum(const_cast<char*>(s->str().c_str()+1), 3, checksum);
     *(s) << "#" << checksum[0] << checksum[1];
 }
 


### PR DESCRIPTION
Hi,

it looks like there is a dublicate + which is added to the gdb protocol. Gdb client kept complaining when trying to connect. With this patch connection between my gdb server (use minigdbstub) and gdb client was working.

Let me know if you have any questions.

Cheers Paul